### PR TITLE
feat [WIP]: Enable 128-bit vector operations on bfloat16 data

### DIFF
--- a/utils/cuda_timer.hpp
+++ b/utils/cuda_timer.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "cuda_utils.hpp"
+
+class CudaTimer {
+public:
+  CudaTimer() {
+    CudaCheck(cudaEventCreate(&start_event));
+    CudaCheck(cudaEventCreate(&stop_event));
+  }
+
+  ~CudaTimer() {
+    CudaCheck(cudaEventDestroy(start_event));
+    CudaCheck(cudaEventDestroy(stop_event));
+  }
+
+  void start(cudaStream_t st = 0) {
+    stream = st;
+    CudaCheck(cudaEventRecord(start_event, stream));
+  }
+
+  float stop() {
+    float milliseconds = 0.;
+    CudaCheck(cudaEventRecord(stop_event, stream));
+    CudaCheck(cudaEventSynchronize(stop_event));
+    CudaCheck(cudaEventElapsedTime(&milliseconds, start_event, stop_event));
+    return milliseconds;
+  }
+
+private:
+  cudaEvent_t start_event;
+  cudaEvent_t stop_event;
+  cudaStream_t stream;
+};

--- a/utils/cuda_utils.hpp
+++ b/utils/cuda_utils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+inline void __cudaCheck(const cudaError err, const char* file, int line) {
+  if (err != cudaSuccess) {
+    fprintf(stderr, "%s(%d): CUDA error: %s.\n", file, line,
+            cudaGetErrorString(err));
+    exit(EXIT_FAILURE);
+  }
+}
+#define CudaCheck(call) __cudaCheck(call, __FILE__, __LINE__)

--- a/vectorized/CMakeLists.txt
+++ b/vectorized/CMakeLists.txt
@@ -9,6 +9,7 @@ include(generic)
 
 find_package(CUDA REQUIRED)
 include_directories(${CUDA_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/../utils)
 
 set(CUDA_NVCC_FLAGS
     "${CUDA_NVCC_FLAGS} --extended-lambda  --keep --source-in-ptx")

--- a/vectorized/README.md
+++ b/vectorized/README.md
@@ -1,1 +1,1 @@
-[TBD]
+uint4 and float4 have native 128-bit load/store support.

--- a/vectorized/kernels.cuh
+++ b/vectorized/kernels.cuh
@@ -2,6 +2,23 @@
 
 #include "vec.cuh"
 
+__global__ void vec_add4(const __bfloat164* a, const __bfloat164* b,
+                         __bfloat164* c, int n) {
+  int i = threadIdx.x + blockDim.x * blockIdx.x;
+  if (i < n) {
+    c[i] = a[i] + b[i];
+  }
+}
+
+__global__ void vec_add8(const __bfloat168* a, const __bfloat168* b,
+                         __bfloat168* c, int n) {
+  int i = 8 * (threadIdx.x + blockDim.x * blockIdx.x);
+  if (i < n) {
+    c[i] = a[i] + b[i];
+  }
+}
+
+/// helper functions
 template <typename DType>
 __global__ void init_data(DType* a, DType* b, DType* c, __bfloat16 v1,
                           __bfloat16 v2, __bfloat16 v3, int n) {
@@ -22,21 +39,5 @@ __global__ void debug_print_bfloat164(const __bfloat164* a, int n) {
 __global__ void debug_print_bfloat168(const __bfloat168* a, int n) {
   for (int i = 0; i < n; ++i) {
     print_bfloat168(a[i]);
-  }
-}
-
-__global__ void vec_add4(const __bfloat164* a, const __bfloat164* b,
-                         __bfloat164* c, int n) {
-  int i = threadIdx.x + blockDim.x * blockIdx.x;
-  if (i < n) {
-    c[i] = a[i] + b[i];
-  }
-}
-
-__global__ void vec_add8(const __bfloat168* a, const __bfloat168* b,
-                         __bfloat168* c, int n) {
-  int i = threadIdx.x + blockDim.x * blockIdx.x;
-  if (i < n) {
-    c[i] = a[i] + b[i];
   }
 }

--- a/vectorized/kernels.cuh
+++ b/vectorized/kernels.cuh
@@ -2,17 +2,9 @@
 
 #include "vec.cuh"
 
-__global__ void vec_add4(const __bfloat164* a, const __bfloat164* b,
-                         __bfloat164* c, int n) {
+template <typename DType>
+__global__ void vec_add(const DType* a, const DType* b, DType* c, int n) {
   int i = threadIdx.x + blockDim.x * blockIdx.x;
-  if (i < n) {
-    c[i] = a[i] + b[i];
-  }
-}
-
-__global__ void vec_add8(const __bfloat168* a, const __bfloat168* b,
-                         __bfloat168* c, int n) {
-  int i = 8 * (threadIdx.x + blockDim.x * blockIdx.x);
   if (i < n) {
     c[i] = a[i] + b[i];
   }
@@ -27,6 +19,12 @@ __global__ void init_data(DType* a, DType* b, DType* c, __bfloat16 v1,
     a[i] = v1;
     b[i] = v2;
     c[i] = v3;
+  }
+}
+
+__global__ void debug_print_bfloat16(const __bfloat16* a, int n) {
+  for (int i = 0; i < n; ++i) {
+    printf("%.2f\n", __bfloat162float(a[i]));
   }
 }
 

--- a/vectorized/main.cu
+++ b/vectorized/main.cu
@@ -3,55 +3,48 @@
 
 #include <stdio.h>
 
+template <const int kN, const unsigned int kThreads>
 int test_vec_add4() {
   using DType = __bfloat164;
-  const int kN = 128;  // each thread process a single bfloat164
 
-  // Allocate device memory
   DType *d_a, *d_b, *d_c;
   cudaError_t err;
 
-  err = cudaMalloc(&d_a, kN * sizeof(DType));
+  int numel = kN / 4;
+  err = cudaMalloc(&d_a, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_a: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  err = cudaMalloc(&d_b, kN * sizeof(DType));
+  err = cudaMalloc(&d_b, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_b: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  err = cudaMalloc(&d_c, kN * sizeof(DType));
+  err = cudaMalloc(&d_c, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_c: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  dim3 threads{128, 1, 1};
-  dim3 grid{1, 1, 1};
-  init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5, 2.3, 0.0, kN);
+  unsigned int blocks = kN / (4 * kThreads);
+  dim3 threads{kThreads, 1, 1};
+  dim3 grid{blocks, 1, 1};
 
-  dim3 threads2{1, 1, 1};
-  dim3 grid2{1, 1, 1};
-
-#if defined(DEBUG)
-  printf("d_a:\n");
-  debug_print_bfloat164<<<grid2, threads2>>>(d_a, kN);
+  init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5, 2.3, 0.0, numel);
   cudaDeviceSynchronize();
 
-  printf("d_b:\n");
-  debug_print_bfloat164<<<grid2, threads2>>>(d_b, kN);
-  cudaDeviceSynchronize();
-#endif
-
-  vec_add4<<<grid, threads>>>(d_a, d_b, d_c, kN);
+  vec_add4<<<grid, threads>>>(d_a, d_b, d_c, numel);
   cudaDeviceSynchronize();
 
-  printf("results:\n");
-  debug_print_bfloat164<<<grid2, threads2>>>(d_c, kN);
-  cudaDeviceSynchronize();
+  {  // debug print
+    dim3 threads{1, 1, 1};
+    dim3 grid{1, 1, 1};
+    debug_print_bfloat164<<<grid, threads>>>(d_c, numel);
+    cudaDeviceSynchronize();
+  }
 
   cudaFree(d_a);
   cudaFree(d_b);
@@ -59,55 +52,49 @@ int test_vec_add4() {
   return 0;
 }
 
+template <const int kN, const unsigned int kThreads>
 int test_vec_add8() {
   using DType = __bfloat168;
-  const int kN = 128;  // each thread process a single bfloat168
 
   DType *d_a, *d_b, *d_c;
   cudaError_t err;
 
-  err = cudaMalloc(&d_a, kN * sizeof(DType));
+  int numel = kN / 8;  // Each __bfloat168 contains 8 elements
+  err = cudaMalloc(&d_a, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_a: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  err = cudaMalloc(&d_b, kN * sizeof(DType));
+  err = cudaMalloc(&d_b, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_b: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  err = cudaMalloc(&d_c, kN * sizeof(DType));
+  err = cudaMalloc(&d_c, numel * sizeof(DType));
   if (err != cudaSuccess) {
     printf("cudaMalloc failed for d_c: %s\n", cudaGetErrorString(err));
     return -1;
   }
 
-  dim3 threads{128, 1, 1};
-  dim3 grid{1, 1, 1};
+  dim3 threads{kThreads, 1, 1};
+  int blocks = kN / (8 * kThreads);
+  dim3 grid{(unsigned int)blocks, 1, 1};
 
-  init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5f, 2.3f, 0.0f, kN);
-
-  dim3 threads2{1, 1, 1};
-  dim3 grid2{1, 1, 1};
-
-#if defined(DEBUG)
-  printf("d_a:\n");
-  debug_print_bfloat164<<<grid2, threads2>>>(d_a, kN);
+  init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5f, 2.3f, 0.0f, numel);
   cudaDeviceSynchronize();
 
-  printf("d_b:\n");
-  debug_print_bfloat164<<<grid2, threads2>>>(d_b, kN);
-  cudaDeviceSynchronize();
-#endif
-
-  vec_add8<<<grid, threads>>>(d_a, d_b, d_c, kN);
+  vec_add8<<<grid, threads>>>(d_a, d_b, d_c, numel);
   cudaDeviceSynchronize();
 
-  printf("d_c:\n");
-  debug_print_bfloat168<<<grid2, threads2>>>(d_c, kN);
-  cudaDeviceSynchronize();
+  {  // debug print
+    dim3 threads{1, 1, 1};
+    dim3 grid{1, 1, 1};
+    printf("d_c:\n");
+    debug_print_bfloat168<<<grid, threads>>>(d_c, numel);
+    cudaDeviceSynchronize();
+  }
 
   cudaFree(d_a);
   cudaFree(d_b);
@@ -116,7 +103,7 @@ int test_vec_add8() {
 }
 
 int main() {
-  test_vec_add4();
-  test_vec_add8();
+  test_vec_add4<1024, 128 /* threads */>();
+  // test_vec_add8<12800, 128 /* threads */>();
   return 0;
 }

--- a/vectorized/main.cu
+++ b/vectorized/main.cu
@@ -1,10 +1,71 @@
+#include "cuda_timer.hpp"
 #include "kernels.cuh"
 #include "vec.cuh"
 
 #include <stdio.h>
 
 template <const int kN, const unsigned int kThreads>
-int test_vec_add4() {
+float test_vec_add1(int warmup = 10, int repeat = 500) {
+  using DType = __bfloat16;
+
+  DType *d_a, *d_b, *d_c;
+  cudaError_t err;
+
+  err = cudaMalloc(&d_a, kN * sizeof(DType));
+  if (err != cudaSuccess) {
+    printf("cudaMalloc failed for d_a: %s\n", cudaGetErrorString(err));
+    return -1;
+  }
+
+  err = cudaMalloc(&d_b, kN * sizeof(DType));
+  if (err != cudaSuccess) {
+    printf("cudaMalloc failed for d_b: %s\n", cudaGetErrorString(err));
+    return -1;
+  }
+
+  err = cudaMalloc(&d_c, kN * sizeof(DType));
+  if (err != cudaSuccess) {
+    printf("cudaMalloc failed for d_c: %s\n", cudaGetErrorString(err));
+    return -1;
+  }
+
+  unsigned int blocks = kN / kThreads;
+  dim3 threads{kThreads, 1, 1};
+  dim3 grid{blocks, 1, 1};
+
+  init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5, 2.3, 0.0, kN);
+  cudaDeviceSynchronize();
+
+  for (int i = 0; i < warmup; ++i)
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, kN);
+  cudaDeviceSynchronize();
+
+  CudaTimer timer;
+  timer.start();
+  for (int i = 0; i < repeat; ++i) {
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, kN);
+  }
+  cudaDeviceSynchronize();
+  float time = timer.stop() / repeat;
+
+  {
+#ifdef DEBUG
+    dim3 threads{1, 1, 1};
+    dim3 grid{1, 1, 1};
+    debug_print_bfloat16<<<grid, threads>>>(d_c, kN);
+    cudaDeviceSynchronize();
+#endif
+  }
+
+  cudaFree(d_a);
+  cudaFree(d_b);
+  cudaFree(d_c);
+
+  return time;
+}
+
+template <const int kN, const unsigned int kThreads>
+float test_vec_add4(int warmup = 10, int repeat = 500) {
   using DType = __bfloat164;
 
   DType *d_a, *d_b, *d_c;
@@ -36,24 +97,36 @@ int test_vec_add4() {
   init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5, 2.3, 0.0, numel);
   cudaDeviceSynchronize();
 
-  vec_add4<<<grid, threads>>>(d_a, d_b, d_c, numel);
+  for (int i = 0; i < warmup; ++i)
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, numel);
   cudaDeviceSynchronize();
 
-  {  // debug print
+  CudaTimer timer;
+  timer.start();
+  for (int i = 0; i < repeat; ++i) {
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, numel);
+  }
+  cudaDeviceSynchronize();
+  float time = timer.stop() / repeat;
+
+  {
+#ifdef DEBUG
     dim3 threads{1, 1, 1};
     dim3 grid{1, 1, 1};
     debug_print_bfloat164<<<grid, threads>>>(d_c, numel);
     cudaDeviceSynchronize();
+#endif
   }
 
   cudaFree(d_a);
   cudaFree(d_b);
   cudaFree(d_c);
-  return 0;
+
+  return time;
 }
 
 template <const int kN, const unsigned int kThreads>
-int test_vec_add8() {
+float test_vec_add8(int warmup = 10, int repeat = 500) {
   using DType = __bfloat168;
 
   DType *d_a, *d_b, *d_c;
@@ -85,25 +158,38 @@ int test_vec_add8() {
   init_data<<<grid, threads>>>(d_a, d_b, d_c, 1.5f, 2.3f, 0.0f, numel);
   cudaDeviceSynchronize();
 
-  vec_add8<<<grid, threads>>>(d_a, d_b, d_c, numel);
+  for (int i = 0; i < warmup; ++i)
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, numel);
   cudaDeviceSynchronize();
 
-  {  // debug print
+  CudaTimer timer;
+  timer.start();
+  for (int i = 0; i < repeat; ++i) {
+    vec_add<DType><<<grid, threads>>>(d_a, d_b, d_c, numel);
+  }
+  cudaDeviceSynchronize();
+  float time = timer.stop() / repeat;
+
+  {
+#ifdef DEBUG
     dim3 threads{1, 1, 1};
     dim3 grid{1, 1, 1};
-    printf("d_c:\n");
     debug_print_bfloat168<<<grid, threads>>>(d_c, numel);
     cudaDeviceSynchronize();
+#endif
   }
 
   cudaFree(d_a);
   cudaFree(d_b);
   cudaFree(d_c);
-  return 0;
+
+  return time;
 }
 
 int main() {
-  test_vec_add4<1024, 128 /* threads */>();
-  // test_vec_add8<12800, 128 /* threads */>();
+  float time1 = test_vec_add1<10240, 256 /* threads */>();
+  float time2 = test_vec_add4<10240, 256 /* threads */>();
+  float time3 = test_vec_add8<10240, 256 /* threads */>();
+  printf("time1: %f, time2: %f, time3: %f\n", time1, time2, time3);
   return 0;
 }

--- a/vectorized/run_build.sh
+++ b/vectorized/run_build.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-set -e # Exit on error
+set -e
 
-# Create build directory if it doesn't exist
 if [ ! -d _build ]; then
     mkdir _build || {
         echo "Failed to create _build directory"
@@ -10,28 +9,38 @@ if [ ! -d _build ]; then
     }
 fi
 
-# Clean previous build artifacts
-if [ -d _build/CMakeFiles ]; then
-    rm -rf _build/CMakeFiles
-fi
-
-if [ -f _build/CMakeCache.txt ]; then
-    rm -f _build/CMakeCache.txt
-fi
-
 cd _build
+
+if [ -f vec_test ]; then
+    rm vec_test
+fi
+
+# Clean previous build artifacts
+if [ -d CMakeFiles ]; then
+    rm -rf CMakeFiles
+fi
+
+if [ -f CMakeCache.txt ]; then
+    rm -f CMakeCache.txt
+fi
 
 cmake ..
 
-make
+make -j32
 
-cd ../
+if [ -f vec_test ]; then
+    echo "build success"
+    ./vec_test >../run.log 2>&1
 
-# Run the executable and capture output
-./_build/vec_test >run.log 2>&1
-RUN_STATUS=$?
-cat run.log
-if [ $RUN_STATUS -ne 0 ]; then
-    echo "Program execution failed"
+    RUN_STATUS=$?
+    cat ../run.log
+    if [ $RUN_STATUS -ne 0 ]; then
+        echo "Program execution failed"
+        exit 1
+    fi
+else
+    echo "build failed"
     exit 1
 fi
+
+cd ../

--- a/vectorized/vec.cuh
+++ b/vectorized/vec.cuh
@@ -9,7 +9,11 @@ typedef __nv_bfloat162 __bfloat162;
 
 #define HOST_DEVICE __forceinline__ __host__ __device__
 
-struct __align__(8) __bfloat164 {  // packed 64-bit data
+// This struct represents a 64-bit vector containing 4 bfloat16 values.
+// It is designed to efficiently utilize GPU's vectorization capabilities
+// beyond the default 32-bit bfloat162 operations.
+// packed 64-bit data, sizeof(bfloat164) = 8
+struct __align__(8) __bfloat164 {
   __bfloat162 x, y;
 
   HOST_DEVICE __bfloat164() : x(), y() {}
@@ -70,7 +74,11 @@ HOST_DEVICE __bfloat164 operator*(const __bfloat164& a, const __bfloat164& b) {
   return __bfloat164(__hmul2(a.x, b.x), __hmul2(a.y, b.y));
 }
 
-struct __align__(16) __bfloat168 {  // packed 128-bit data
+// This struct represents a 128-bit vector containing 8 bfloat16 values.
+// It is designed to efficiently utilize GPU's vectorization capabilities
+// beyond the default 32-bit bfloat162 operations.
+// packed 128-bit data, sizeof(bfloat168) = 16
+struct __align__(16) __bfloat168 {
   __bfloat164 x, y;
 
   HOST_DEVICE __bfloat168() : x(), y() {}


### PR DESCRIPTION
Work in progress. Implementations to enable 128-bit vector operations on bfloat16 data.

- Refined implementations.
- Added timing utilities for performance measurement and benchmarking.